### PR TITLE
Force serviceEmailaddress to contact me form

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -5,6 +5,7 @@
   "emailTemplateTeam": "elliott.bouher@digital.justice.gov.uk",
   "emailTemplateUser": "Thank you for submitting our contact me form.\r\n\r\nA member of the Form Builder team will be in contact with you soon.\r\n\r\nThank you,\r\nForm Builder Team",
   "name": "Form Builder: Find out more",
+  "serviceEmailAddress": "form-builder@digital.justice.gov.uk",
   "phase": "alpha",
   "phaseText": "Service phase text goes here"
 }


### PR DESCRIPTION
On the runner the service#serviceEmailAddress is underfined,
so the quick fix is to force the config.

When the runner get the instance property

```
email.address.from
propDefaultValue: undefined
propValue: "[% service#name %]" <[% service#serviceEmailAddress %]>
```

The serviceEmailAddress is blank on the runner context but does exist
on the config.json in the fb-components.